### PR TITLE
Skip reintroduced wind speed None exception bug

### DIFF
--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -264,7 +264,7 @@ class OpenMeteoSolarForecast:
             gti_inst_arr = data["minutely_15"]["global_tilted_irradiance_instant"]
             temp_arr = data["minutely_15"]["temperature_2m"]
             wind_arr = [
-                wind_speed * 1000 / 3600
+                wind_speed * 1000 / 3600 if wind_speed is not None else None
                 for wind_speed in data["minutely_15"]["wind_speed_10m"]
             ]
 


### PR DESCRIPTION
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 315, in _async_refresh self.data = await self._async_update_data()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/config/custom_components/open_meteo_solar_forecast/coordinator.py", line 57, in _async_update_data return await self.forecast.estimate()
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/.local/lib/python3.12/site-packages/open_meteo_solar_forecast/open_meteo_solar_forecast.py", line 160, in estimate wind_speed * 1000 / 3600
~~~~~~~~~~~^~~~~~
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'

Fixes: 2ae2afa ("Implement support for multiple PV arrays (#8)")