### PR TITLE
Fix model query parameter

### DIFF
--- a/src/open_meteo_solar_forecast/exceptions.py
+++ b/src/open_meteo_solar_forecast/exceptions.py
@@ -23,3 +23,7 @@ class OpenMeteoSolarForecastRequestError(OpenMeteoSolarForecastError):
 
 class OpenMeteoSolarForecastRatelimitError(OpenMeteoSolarForecastRequestError):
     """OpenMeteoSolarForecast rate limit exception."""
+
+
+class OpenMeteoSolarForecastInvalidModel(OpenMeteoSolarForecastError):
+    """OpenMeteoSolarForecast invalid model exception."""

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -16,6 +16,7 @@ from .exceptions import (
     OpenMeteoSolarForecastConfigError,
     OpenMeteoSolarForecastConnectionError,
     OpenMeteoSolarForecastError,
+    OpenMeteoSolarForecastInvalidModel,
     OpenMeteoSolarForecastRatelimitError,
     OpenMeteoSolarForecastRequestError,
 )
@@ -141,8 +142,12 @@ class OpenMeteoSolarForecast:
 
         # Add the weather model to the request
         if self.weather_model:
+            if "," in self.weather_model:
+                raise OpenMeteoSolarForecastInvalidModel(
+                    "Multiple models are not supported"
+                )
             params = params or {}
-            params["model"] = self.weather_model
+            params["models"] = self.weather_model
 
         # Get response from the API
         response = await self.session.request(


### PR DESCRIPTION
It is supposed to be "models" not "model." We only support one model not multiple, so just one must be passed. Check for it.

Fixes: https://github.com/rany2/open-meteo-solar-forecast/pull/25