### PR TITLE
Update Incorrect cell temperature estimation

### DIFF
--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -217,7 +217,7 @@ class OpenMeteoSolarForecast:
                     - Power output formula: P = Pmax * (G / Gstc) * (1 + α * (Tc - Tstc)) * ηDC (see p.509)
                       Source: https://www.researchgate.net/publication/372240079_Solar_Prediction_Strategy_for_Managing_Virtual_Power_Stations
             """
-            temp_cell = t_amb + gti * RossModelConstants.NOT_SO_WELL_COOL
+            temp_cell = t_amb + gti * RossModelConstants.NOT_SO_WELL_COOLED
             power = dc_wp
             power *= gti / G_STC
             power *= 1 + ALPHA_TEMP * (temp_cell - TEMP_STC_CELL)

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -200,7 +200,19 @@ class OpenMeteoSolarForecast:
 
             Formulas:
             ---------
+                Assuming https://www.mdpi.com/2071-1050/14/3/1500 equation 1 + 2 as well as table 1
+                the formula:
+                
                 Tc=Ta + (G/Gnoct) * k
+                and
+                P=Pmax * (G/Gstc) * (1 + α * (Tc-Tstc)) * ηDC (p.509)
+                
+                must be:
+                
+                Tc=Ta + G * k
+                and
+                P=Pmax * G * (1 + α * (Tc-Tstc)) * ηDC (p.509)
+                
                 Where k is the Ross coefficient. Assuming that this is a typical
                 home installation, we use the "Not so well cooled" value from
                 Table 1 which is 0.0342. TODO: Make this configurable.
@@ -208,8 +220,16 @@ class OpenMeteoSolarForecast:
 
                 P=Pmax * (G/Gstc) * (1 + α * (Tc-Tstc)) * ηDC (p.509)
                 Source: https://www.researchgate.net/publication/372240079_Solar_Prediction_Strategy_for_Managing_Virtual_Power_Stations
+               
+                Instead of: 
+                
+                temp_cell = t_amb + (gti / G_NOCT) * RossModelConstants.NOT_SO_WELL_COOL
+
+                it must be:
+
+                temp_cell = t_amb + gti * RossModelConstants.NOT_SO_WELL_COOL
             """
-            temp_cell = t_amb + (gti / G_NOCT) * RossModelConstants.NOT_SO_WELL_COOLED
+            temp_cell = t_amb + gti * RossModelConstants.NOT_SO_WELL_COOL
             power = dc_wp
             power *= gti / G_STC
             power *= 1 + ALPHA_TEMP * (temp_cell - TEMP_STC_CELL)

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -200,34 +200,22 @@ class OpenMeteoSolarForecast:
 
             Formulas:
             ---------
-                Assuming https://www.mdpi.com/2071-1050/14/3/1500 equation 1 + 2 as well as table 1
-                the formula:
-                
-                Tc=Ta + (G/Gnoct) * k
-                and
-                P=Pmax * (G/Gstc) * (1 + α * (Tc-Tstc)) * ηDC (p.509)
-                
-                must be:
-                
-                Tc=Ta + G * k
-                and
-                P=Pmax * G * (1 + α * (Tc-Tstc)) * ηDC (p.509)
-                
-                Where k is the Ross coefficient. Assuming that this is a typical
-                home installation, we use the "Not so well cooled" value from
-                Table 1 which is 0.0342. TODO: Make this configurable.
-                Source: https://www.researchgate.net/publication/275438802_Thermal_effects_of_the_extended_holographic_regions_for_holographic_planar_concentrator
+                According to https://www.mdpi.com/2071-1050/14/3/1500 (equations 1 and 2) and Table 1,
+                the temperature formula should be:
+                     Tc = Ta + G * k
+                where:
+                    - Tc is the cell temperature
+                    - Ta is the ambient temperature
+                    - G is the irradiance (W/m²)
+                    - k is the Ross coefficient
 
-                P=Pmax * (G/Gstc) * (1 + α * (Tc-Tstc)) * ηDC (p.509)
-                Source: https://www.researchgate.net/publication/372240079_Solar_Prediction_Strategy_for_Managing_Virtual_Power_Stations
-               
-                Instead of: 
-                
-                temp_cell = t_amb + (gti / G_NOCT) * RossModelConstants.NOT_SO_WELL_COOL
+                For a typical residential PV installation, we use the "Not so well cooled" Ross coefficient
+                from Table 1, which is 0.0342. (TODO: make this coefficient configurable.)
 
-                it must be:
-
-                temp_cell = t_amb + gti * RossModelConstants.NOT_SO_WELL_COOL
+                References:
+                    - Ross model source: https://www.researchgate.net/publication/275438802_Thermal_effects_of_the_extended_holographic_regions_for_holographic_planar_concentrator
+                    - Power output formula: P = Pmax * (G / Gstc) * (1 + α * (Tc - Tstc)) * ηDC (see p.509)
+                      Source: https://www.researchgate.net/publication/372240079_Solar_Prediction_Strategy_for_Managing_Virtual_Power_Stations
             """
             temp_cell = t_amb + gti * RossModelConstants.NOT_SO_WELL_COOL
             power = dc_wp


### PR DESCRIPTION
Cell temperature estimation using Ross model incorrectly uses the formula which uses module temperature delta between module normal operating cell temperature (NOCT) and normal operating conditions (20 degree C) instead of the ross model factor ( (NOCT - 20) / 800 ) while the given default value is the model factor already (cf. https://www.mdpi.com/2071-1050/14/3/1500 equation 1 + 2 as well as table 1)

The relevant Part in the paper that you referenced ist equation 3: T(c) = T(amb)+ (T(NOCT)-T(amb,NOCT))/G(NOCT)*G(Panel), or simplified to T(c) = T(amb) + k(ross)*G(Panel)

If you compare this to Tc=Ta + (G/Gnoct) * k, which you cite in your Posting, you will notice that k here would be a different factor, to be precise, k = k(ross) * G(Noct), i.e. k(ross) * 800.

The factor rossmodel defined in the template with default value 0.0342, is already the result of (T(NOCT)-T(amb,NOCT))/G(NOCT), with T(NOCT) = 47.2. Due to this, the correction of the cell temparature ist too Low by a Factor of 800, i.e. we underestimate the cell Temperaturen massively and hence overestimate the Power Output of the cells.

