### PR TITLE
Add snow coverage feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ async def main() -> None:
 		use_horizon=True,
 		partial_shading=True,
         horizon_map=((0,30),(360,30),
-		max_snowcover_depth=5.0,
+		max_snowcover_depth_cm=5.0,
     ) as forecast:
         estimate = await forecast.estimate()
         print(estimate)
@@ -88,7 +88,7 @@ if __name__ == "__main__":
 | `use_horizon` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use horizon shading (optional, default = False) |
 | `partial_shading` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use interpret horizon shading as partial [experimental] (optional, default = False) |
 | `horizon_map` | `tuple of 2-tuples \| list[tuple of 2-tuples]` | Map of the horizon* (required if use_horizon = True) |
-| `max_snowcover_depth` | `float \| list[float] \| tuple[float, ...]` | Critical snow coverage (cm) resulting in zero panel power [experimental] (required, default = 0.0 turns this off) |
+| `max_snowcover_depth_cm` | `float \| list[float] \| tuple[float, ...]` | Critical snow coverage (cm) resulting in zero panel power [experimental] (required, default = 0.0 turns this off) |
 
 ### Multiple PV arrays
 
@@ -109,7 +109,7 @@ async with OpenMeteoSolarForecast(
     horizon_map=[
         ((0, 0), (360, 0)),
         ((0, 20), (180, 10), (360, 20)),
-    max_snowcover_depth=[5.0,5.0],
+    max_snowcover_depth_cm=[5.0,5.0],
     ],
 ) as forecast:
     estimate = await forecast.estimate()
@@ -122,7 +122,7 @@ The **horizon map** is a tuple of 2-tuples, where each 2-tuple consists of (azim
 
 If **partial_shading** is disabled and a shadow is detected on the module, only the diffuse irradiation will be used to calculate the power output. This is useful if the shading is predominantly from far-away objects, which can be treated as shading the whole module at once or not. If partial_shading is enabled and a shadow is detected on the module, the shadow is treated as partial. This is useful if the shading arises from close-by objects, which cast 'hard' contoured shadows on the module. In this case, an experimental calculation is used taking into account the 'sunniness' of the conditions. This is done via the ratio of diffuse and direct irradiation. A large share of diffuse irradiation (cloudy day) will let the module run as homogeneously shaded at diffuse power. A small share of diffuse irradiation (sunny) day will reduce the diffuse power even more, since hard partial shadows can shut down the module completely.
 
-If **max_snowcover_depth** is set to a value > 0, this value will be interpreted as the snow cover depth (in centimeters) that results in zero power from the module. In between, a linear interpolation over the forecast snow cover depth is applied. (A value of 0 turns this feature completely off.)
+If **max_snowcover_depth_cm** is set to a value > 0, this value will be interpreted as the snow cover depth (in centimeters) that results in zero power from the module. In between, a linear interpolation over the forecast snow cover depth is applied. (A value of 0 turns this feature completely off.)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ async def main() -> None:
 		use_horizon=True,
 		partial_shading=True,
         horizon_map=((0,30),(360,30),
+		max_snowcover_depth=5.0,
     ) as forecast:
         estimate = await forecast.estimate()
         print(estimate)
@@ -85,8 +86,9 @@ if __name__ == "__main__":
 | `azimuth` | `int \| list[int] \| tuple[int, ...]` | The direction the solar panels are facing (required) |
 | `dc_kwp` | `float \| list[float] \| tuple[float, ...]` | The size of the solar panels in kWp (required) |
 | `use_horizon` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use horizon shading (optional, default = False) |
-| `partial_shading` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use interpret horizon shading as partial** [experimental] (optional, default = False) |
+| `partial_shading` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use interpret horizon shading as partial [experimental] (optional, default = False) |
 | `horizon_map` | `tuple of 2-tuples \| list[tuple of 2-tuples]` | Map of the horizon* (required if use_horizon = True) |
+| `max_snowcover_depth` | `float \| list[float] \| tuple[float, ...]` | Critical snow coverage (cm) resulting in zero panel power [experimental] (required, default = 0.0 turns this off) |
 
 ### Multiple PV arrays
 
@@ -107,6 +109,7 @@ async with OpenMeteoSolarForecast(
     horizon_map=[
         ((0, 0), (360, 0)),
         ((0, 20), (180, 10), (360, 20)),
+    max_snowcover_depth=[5.0,5.0],
     ],
 ) as forecast:
     estimate = await forecast.estimate()
@@ -115,9 +118,11 @@ async with OpenMeteoSolarForecast(
 Scalar values are still supported and are automatically applied to all arrays
 when mixed with list/tuple inputs.
 
-*) The horizon map is a tuple of 2-tuples, where each 2-tuple consists of (azimuth,elevation). Azimuth is the compass direction in degrees (0° = north, 180° = south). The horizon map has to cover the whole range of azimuths that the sun travels through over the year (recommendation: plot the horizon from 0 to 360°). Elevation is the associated angle in degrees of any object (hill, tree, ...) casting a shadow on the modules. The elevation angle has to be in the range 0° (flat, ideal horizon) to 90° (in the sky directly over the modules). The map has to be monotonic on the azimuth axis, however this is not checked by the script! Elevation values in between are interpolated along the azimuth axis, thus non-monotonic values will give wrong results. The horizon map can also be passed from a text file, see the included example estimate_horizon.py.
+The **horizon map** is a tuple of 2-tuples, where each 2-tuple consists of (azimuth,elevation). Azimuth is the compass direction in degrees (0° = north, 180° = south). The horizon map has to cover the whole range of azimuths that the sun travels through over the year (recommendation: plot the horizon from 0 to 360°). Elevation is the associated angle in degrees of any object (hill, tree, ...) casting a shadow on the modules. The elevation angle has to be in the range 0° (flat, ideal horizon) to 90° (in the sky directly over the modules). The map has to be monotonic on the azimuth axis, however this is not checked by the script! Elevation values in between are interpolated along the azimuth axis, thus non-monotonic values will give wrong results. The horizon map can also be passed from a text file, see the included example estimate_horizon.py.
 
-**) If partial_shading is disabled and a shadow is detected on the module, only the diffuse irradiation will be used to calculate the power output. This is useful if the shading is predominantly from far-away objects, which can be treated as shading the whole module at once or not. If partial_shading is enabled and a shadow is detected on the module, the shadow is treated as partial. This is useful if the shading arises from close-by objects, which cast 'hard' contoured shadows on the module. In this case, an experimental calculation is used taking into account the 'sunniness' of the conditions. This is done via the ratio of diffuse and direct irradiation. A large share of diffuse irradiation (cloudy day) will let the module run as homogeneously shaded at diffuse power. A small share of diffuse irradiation (sunny) day will reduce the diffuse power even more, since hard partial shadows can shut down the module completely.
+If **partial_shading** is disabled and a shadow is detected on the module, only the diffuse irradiation will be used to calculate the power output. This is useful if the shading is predominantly from far-away objects, which can be treated as shading the whole module at once or not. If partial_shading is enabled and a shadow is detected on the module, the shadow is treated as partial. This is useful if the shading arises from close-by objects, which cast 'hard' contoured shadows on the module. In this case, an experimental calculation is used taking into account the 'sunniness' of the conditions. This is done via the ratio of diffuse and direct irradiation. A large share of diffuse irradiation (cloudy day) will let the module run as homogeneously shaded at diffuse power. A small share of diffuse irradiation (sunny) day will reduce the diffuse power even more, since hard partial shadows can shut down the module completely.
+
+If **max_snowcover_depth** is set to a value > 0, this value will be interpreted as the snow cover depth (in centimeters) that results in zero power from the module. In between, a linear interpolation over the forecast snow cover depth is applied. (A value of 0 turns this feature completely off.)
 
 ## Contributing
 

--- a/examples/estimate_horizon_comparison.py
+++ b/examples/estimate_horizon_comparison.py
@@ -15,7 +15,7 @@ async def main() -> None:
     horizon_data = numpy.genfromtxt("horizon_complex.txt", delimiter="\t", dtype=float)
     hm = tuple([tuple(row) for row in horizon_data])
     
-    max_snowcover_depth = 5 # cm
+    max_snowcover_depth_cm = 5 # cm
     
     latitude=51.4
     longitude=11.9
@@ -37,7 +37,7 @@ async def main() -> None:
         use_horizon=False,
         horizon_map=hm, # tuple of 2-tuples
         partial_shading=False,
-        max_snowcover_depth=max_snowcover_depth,
+        max_snowcover_depth_cm=max_snowcover_depth_cm,
         past_days=past_days,
         forecast_days=forecast_days,
     ) as forecast:
@@ -53,7 +53,7 @@ async def main() -> None:
         use_horizon=True,
         horizon_map=hm, # tuple of 2-tuples
         partial_shading=False,
-        max_snowcover_depth=max_snowcover_depth,
+        max_snowcover_depth_cm=max_snowcover_depth_cm,
         past_days=past_days,
         forecast_days=forecast_days,
     ) as forecast2:
@@ -69,7 +69,7 @@ async def main() -> None:
         use_horizon=True,
         horizon_map=hm, # tuple of 2-tuples
         partial_shading=True,
-        max_snowcover_depth=max_snowcover_depth,
+        max_snowcover_depth_cm=max_snowcover_depth_cm,
         past_days=past_days,
         forecast_days=forecast_days,
     ) as forecast3:

--- a/examples/estimate_horizon_comparison.py
+++ b/examples/estimate_horizon_comparison.py
@@ -15,6 +15,7 @@ async def main() -> None:
     horizon_data = numpy.genfromtxt("horizon_complex.txt", delimiter="\t", dtype=float)
     hm = tuple([tuple(row) for row in horizon_data])
     
+    max_snowcover_depth = 5 # cm
     
     latitude=51.4
     longitude=11.9
@@ -36,6 +37,7 @@ async def main() -> None:
         use_horizon=False,
         horizon_map=hm, # tuple of 2-tuples
         partial_shading=False,
+        max_snowcover_depth=max_snowcover_depth,
         past_days=past_days,
         forecast_days=forecast_days,
     ) as forecast:
@@ -51,6 +53,7 @@ async def main() -> None:
         use_horizon=True,
         horizon_map=hm, # tuple of 2-tuples
         partial_shading=False,
+        max_snowcover_depth=max_snowcover_depth,
         past_days=past_days,
         forecast_days=forecast_days,
     ) as forecast2:
@@ -66,6 +69,7 @@ async def main() -> None:
         use_horizon=True,
         horizon_map=hm, # tuple of 2-tuples
         partial_shading=True,
+        max_snowcover_depth=max_snowcover_depth,
         past_days=past_days,
         forecast_days=forecast_days,
     ) as forecast3:

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -49,6 +49,7 @@ class OpenMeteoSolarForecast:
     use_horizon: bool | list[bool] = False
     partial_shading: bool | list[bool] = False
     horizon_map: tuple(tuple(float)) | list[tuple(tuple(float))] = ((0.0,20.0),(360.0,20.0))
+    max_snowcover_depth: float | list[float] = 0.0
 
     session: ClientSession | None = None
     _close_session: bool = False
@@ -126,6 +127,7 @@ class OpenMeteoSolarForecast:
         self.horizon_map = test_param_len(
             "horizon_map", self.dc_kwp, tuple_as_list=False
         )
+        self.max_snowcover_depth = test_param_len("max_snowcover_depth", self.dc_kwp)
 
     async def _request(
         self,
@@ -340,6 +342,7 @@ class OpenMeteoSolarForecast:
             use_horizon,
             partial_shading,
             horizon_map,
+            max_snowcover_depth,
         ) in zip(
             self.azimuth,
             self.declination,
@@ -352,6 +355,7 @@ class OpenMeteoSolarForecast:
             self.use_horizon,
             self.partial_shading,
             self.horizon_map,
+            self.max_snowcover_depth,
             strict=True,
         ):
             '''
@@ -369,7 +373,7 @@ class OpenMeteoSolarForecast:
                 "azimuth": str(azimuth),
                 "tilt": str(declination),
                 "minutely_15": "temperature_2m"
-                ",global_tilted_irradiance,global_tilted_irradiance_instant,diffuse_radiation,diffuse_radiation_instant,direct_radiation,direct_radiation_instant",
+                ",global_tilted_irradiance,global_tilted_irradiance_instant,diffuse_radiation,diffuse_radiation_instant,direct_radiation,direct_radiation_instant,snow_depth",
                 "daily": "sunrise,sunset",
                 "forecast_days": str(self.forecast_days),
                 "past_days": str(self.past_days),
@@ -386,7 +390,8 @@ class OpenMeteoSolarForecast:
             dhi_inst_arr = data["minutely_15"]["diffuse_radiation_instant"]
             dr_avg_arr = data["minutely_15"]["direct_radiation"]
             dr_inst_arr = data["minutely_15"]["direct_radiation_instant"]
-            temp_arr = data["minutely_15"]["temperature_2m"]
+            snow_depth_arr = data["minutely_15"]["snow_depth"]
+            temp_arr = data["minutely_15"]["temperature_2m"]            
             if utc_offset is None:
                 utc_offset = data["utc_offset_seconds"]
             elif utc_offset != data["utc_offset_seconds"]:
@@ -435,7 +440,7 @@ class OpenMeteoSolarForecast:
                     False
                     for t in time_arr
                 ]
-
+            
             # Convert kW to W
             dc_wp = dc_kwp * 1000
 
@@ -503,6 +508,13 @@ class OpenMeteoSolarForecast:
                 else:
                     irr_avg = g_avg
                     irr_inst = g_inst
+                    
+                # Apply snow coverage as linear regression from 0 (panels not covered) to max_snowcover_depth (in cm, panels producing 0 W)
+                # multiply snow_depth by 100 (m to cm) - clamp to 0...1 interval
+                if max_snowcover_depth > 0:
+                    snowcover_factor =1.0 - min( (snow_depth_arr [i]*100)/max_snowcover_depth , 1.0)
+                    irr_avg *= snowcover_factor
+                    irr_inst *= snowcover_factor
 
                 # Calculate and store the power generated
                 w_avg[time_start] += gen_power(irr_avg, temp_avg, eff_damped)

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -49,7 +49,7 @@ class OpenMeteoSolarForecast:
     use_horizon: bool | list[bool] = False
     partial_shading: bool | list[bool] = False
     horizon_map: tuple(tuple(float)) | list[tuple(tuple(float))] = ((0.0,20.0),(360.0,20.0))
-    max_snowcover_depth: float | list[float] = 0.0
+    max_snowcover_depth_cm: float | list[float] = 0.0
 
     session: ClientSession | None = None
     _close_session: bool = False
@@ -127,7 +127,7 @@ class OpenMeteoSolarForecast:
         self.horizon_map = test_param_len(
             "horizon_map", self.dc_kwp, tuple_as_list=False
         )
-        self.max_snowcover_depth = test_param_len("max_snowcover_depth", self.dc_kwp)
+        self.max_snowcover_depth_cm = test_param_len("max_snowcover_depth_cm", self.dc_kwp)
 
     async def _request(
         self,
@@ -342,7 +342,7 @@ class OpenMeteoSolarForecast:
             use_horizon,
             partial_shading,
             horizon_map,
-            max_snowcover_depth,
+            max_snowcover_depth_cm,
         ) in zip(
             self.azimuth,
             self.declination,
@@ -355,7 +355,7 @@ class OpenMeteoSolarForecast:
             self.use_horizon,
             self.partial_shading,
             self.horizon_map,
-            self.max_snowcover_depth,
+            self.max_snowcover_depth_cm,
             strict=True,
         ):
             '''
@@ -509,10 +509,10 @@ class OpenMeteoSolarForecast:
                     irr_avg = g_avg
                     irr_inst = g_inst
                     
-                # Apply snow coverage as linear regression from 0 (panels not covered) to max_snowcover_depth (in cm, panels producing 0 W)
+                # Apply snow coverage as linear regression from 0 (panels not covered) to max_snowcover_depth_cm (in cm, panels producing 0 W)
                 # multiply snow_depth by 100 (m to cm) - clamp to 0...1 interval
-                if max_snowcover_depth > 0:
-                    snowcover_factor =1.0 - min( (snow_depth_arr [i]*100)/max_snowcover_depth , 1.0)
+                if max_snowcover_depth_cm > 0:
+                    snowcover_factor =1.0 - min( (snow_depth_arr [i]*100)/max_snowcover_depth_cm , 1.0)
                     irr_avg *= snowcover_factor
                     irr_inst *= snowcover_factor
 


### PR DESCRIPTION
A critical snow cover depth can be specified, at which the module produce zero power. Linear interpolation in between.
EDIT: The HA integration update is already prepared and I would again push it once there is a new OMSF package release.