### PR TITLE
Add exact 15-minute forecast energy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ This library returns a lot of different data, based on the API:
 - Estimated Energy Production - This Hour (kWh)
 - Estimated Energy Production - Next Hour (kWh)
 - Estimated Energy Production - Remaining today (kWh)
+- `Estimate.wh_period_15m`: exact modeled energy in Wh for each 15-minute
+  interval, keyed by its timezone-aware interval-start timestamp. It is derived
+  from the interval-average modeled power after array combination and inverter
+  clipping. `Estimate.watts` is instantaneous modeled power and is not an
+  equivalent source for interval energy.
 
 ### Power
 

--- a/src/open_meteo_solar_forecast/models.py
+++ b/src/open_meteo_solar_forecast/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 def _timed_value(at: dt.datetime, data: dict[dt.datetime, int]) -> int | None:
@@ -76,6 +76,7 @@ class Estimate:
         watts: Estimated solar power output per time period.
         wh_period: Estimated solar energy production differences per hour.
         wh_days: Estimated solar energy production per day.
+        wh_period_15m: Estimated solar energy production per 15-minute interval.
 
     """
 
@@ -83,6 +84,7 @@ class Estimate:
     wh_period: dict[dt.datetime, int]
     wh_days: dict[dt.datetime, int]
     api_timezone: dt.timezone
+    wh_period_15m: dict[dt.datetime, float] = field(default_factory=dict)
 
     @property
     def timezone(self) -> timezone:

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime as dt
 from datetime import timedelta, timezone
@@ -24,6 +25,13 @@ from .exceptions import (
     OpenMeteoSolarForecastRequestError,
 )
 from .models import Estimate
+
+
+def _quarter_hour_energy(
+    average_power: Mapping[dt, int | float],
+) -> dict[dt, float]:
+    """Convert PT15M average power to energy for each exact interval."""
+    return {timestamp: power * 0.25 for timestamp, power in average_power.items()}
 
 
 @dataclass
@@ -515,6 +523,10 @@ class OpenMeteoSolarForecast:
         for time in w_inst:
             w_inst[time] = min(w_inst[time], ac_wp)
 
+        # Convert already-combined and inverter-clipped average power to exact
+        # energy for each half-open interval [time, time + 15 minutes).
+        wh_period_15m = _quarter_hour_energy(w_avg)
+
         # Calculate the average power generated per hour
         wh_period: dict[dt, int] = {}
         wh_period_count: dict[dt, int] = {}
@@ -536,6 +548,7 @@ class OpenMeteoSolarForecast:
             wh_period=wh_period,
             wh_days=wh_days,
             api_timezone=tz,
+            wh_period_15m=wh_period_15m,
         )
 
     async def close(self) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for open-meteo-solar-forecast."""

--- a/tests/test_wh_period_15m.py
+++ b/tests/test_wh_period_15m.py
@@ -1,0 +1,100 @@
+"""Tests for exact quarter-hour forecast energy."""
+
+# ruff: noqa: S101
+
+import datetime as dt
+import math
+import unittest
+from pathlib import Path
+
+from open_meteo_solar_forecast.models import Estimate
+from open_meteo_solar_forecast.open_meteo_solar_forecast import _quarter_hour_energy
+
+
+class QuarterHourEnergyTests(unittest.TestCase):
+    """Verify the exact PT15M energy contract."""
+
+    def test_estimate_addition_is_backward_compatible(self) -> None:
+        """Keep existing positional Estimate construction valid."""
+        estimate = Estimate({}, {}, {}, dt.UTC)
+
+        assert estimate.wh_period_15m == {}
+        assert estimate.watts == {}
+        assert estimate.wh_period == {}
+        assert estimate.wh_days == {}
+
+    def test_interval_energy_keys_values_and_hourly_conservation(self) -> None:
+        """Preserve aware keys and conserve complete-hour energy."""
+        timezone = dt.timezone(dt.timedelta(hours=2))
+        hour = dt.datetime(2026, 8, 14, 12, tzinfo=timezone)
+        average_power = {
+            hour + dt.timedelta(minutes=offset): value
+            for offset, value in zip(
+                (0, 15, 30, 45), (100, 200, 300, 400), strict=True
+            )
+        }
+
+        periods = _quarter_hour_energy(average_power)
+        existing_hourly_energy = sum(average_power.values()) / len(average_power)
+
+        assert list(periods) == list(average_power)
+        assert all(
+            timestamp.utcoffset() == dt.timedelta(hours=2) for timestamp in periods
+        )
+        assert periods[hour] == 25.0
+        assert math.isclose(
+            sum(periods.values()), existing_hourly_energy, rel_tol=1e-12
+        )
+
+    def test_combined_clipped_power_is_passed_through_once(self) -> None:
+        """Convert an already combined and clipped value exactly once."""
+        start = dt.datetime(2026, 8, 14, 12, tzinfo=dt.UTC)
+        # The estimate path combines arrays and clips w_avg before conversion.
+        periods = _quarter_hour_energy({start: 10_000})
+
+        assert periods == {start: 2_500.0}
+
+    def test_conversion_follows_array_combination_and_inverter_clipping(self) -> None:
+        """Keep conversion downstream of existing combination and clipping."""
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "src/open_meteo_solar_forecast/open_meteo_solar_forecast.py"
+        ).read_text(encoding="utf-8")
+
+        combined = source.index("w_avg[time_start] +=")
+        clipped = source.index("w_avg[time] = min")
+        converted = source.index("wh_period_15m = _quarter_hour_energy(w_avg)")
+        returned = source.index("wh_period_15m=wh_period_15m")
+
+        assert combined < clipped < converted < returned
+        assert "watts=w_inst" in source
+        assert "wh_period=wh_period" in source
+        assert "wh_days=wh_days" in source
+
+    def test_missing_source_periods_do_not_create_zero_intervals(self) -> None:
+        """Keep legitimate zeroes without filling absent intervals."""
+        start = dt.datetime(2026, 8, 14, 12, tzinfo=dt.UTC)
+
+        periods = _quarter_hour_energy({start: 0})
+
+        assert periods == {start: 0.0}
+        assert start + dt.timedelta(minutes=15) not in periods
+
+    def test_timezone_offsets_remain_part_of_timestamp_identity(self) -> None:
+        """Keep repeated civil times distinct across a DST offset change."""
+        summer = dt.datetime(
+            2026, 10, 25, 2, tzinfo=dt.timezone(dt.timedelta(hours=2))
+        )
+        winter = dt.datetime(
+            2026, 10, 25, 2, tzinfo=dt.timezone(dt.timedelta(hours=1))
+        )
+
+        periods = _quarter_hour_energy({summer: 100, winter: 200})
+
+        assert periods[summer] == 25.0
+        assert periods[winter] == 50.0
+        assert summer.isoformat() != winter.isoformat()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds an exact 15-minute forecast energy series to `Estimate` as:

`wh_period_15m: dict[datetime, float]`

The new field is derived from the existing interval-average modeled power
series (`w_avg`) after array aggregation and inverter clipping.

Semantics:
- unit: Wh
- resolution: PT15M
- key: timezone-aware interval-start datetime
- interval: `[timestamp, timestamp + 15 minutes)`

Existing public fields remain unchanged:
- `watts`
- `wh_period`
- `wh_days`

This is intentionally distinct from `watts`, which represents modeled
instantaneous power and therefore should not be treated as canonical
15-minute interval energy.

For each complete hour, the four PT15M energy values conserve the existing
hourly `wh_period` value within floating-point tolerance.

The change is additive and backward compatible.

Tests cover the new field, timezone-aware interval identity, hourly energy
conservation, array aggregation/inverter clipping, missing intervals, zero
energy intervals, and compatibility with the existing estimate fields.