### PR TITLE
Add per-array inverter capacity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ if __name__ == "__main__":
 | `declination` | `int \| list[int] \| tuple[int, ...]` | The tilt of the solar panels (required) |
 | `azimuth` | `int \| list[int] \| tuple[int, ...]` | The direction the solar panels are facing, using the Open-Meteo convention: 0 = south, -90 = east, 90 = west, ±180 = north. To convert a compass bearing (0 = north, 90 = east, 180 = south, 270 = west), subtract 180. (required) |
 | `dc_kwp` | `float \| list[float] \| tuple[float, ...]` | The size of the solar panels in kWp (required) |
+| `ac_kwp` | `float \| list[float \| None] \| tuple[float \| None, ...]` | The inverter capacity in kW. A scalar models a single inverter shared by all arrays (the combined output is clamped); a list/tuple models one inverter per array (each array's output is clamped individually). `None` entries mean no limit for that array. (optional, default = no limit) |
 | `tracking` | `str \| list[str] \| tuple[str, ...]` | Solar tracker type: `"none"`, `"azimuth"`, `"tilt"` or `"dual"` (optional, default = "none") |
 | `use_horizon` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use horizon shading (optional, default = False) |
 | `partial_shading` | `bool \| list[bool] \| tuple[bool, ...]` | Whether to use interpret horizon shading as partial [experimental] (optional, default = False) |
@@ -123,6 +124,28 @@ async with OpenMeteoSolarForecast(
 
 Scalar values are still supported and are automatically applied to all arrays
 when mixed with list/tuple inputs.
+
+### Multiple inverters
+
+If each array is connected to its own inverter, pass `ac_kwp` as a list/tuple
+with one capacity per array. Each array's output is then clamped to its own
+inverter capacity before the outputs are combined:
+
+```python
+async with OpenMeteoSolarForecast(
+    latitude=[52.16, 52.16],
+    longitude=[4.47, 4.47],
+    declination=[20, 35],
+    azimuth=[-90, 90],
+    dc_kwp=[2.4, 1.8],
+    ac_kwp=[2.0, 1.5],  # one inverter per array
+) as forecast:
+    estimate = await forecast.estimate()
+```
+
+Use `None` for arrays without an inverter limit, e.g. `ac_kwp=[2.0, None]`.
+A scalar `ac_kwp` keeps the previous behaviour: a single inverter shared by
+all arrays, clamping the combined output.
 
 The **horizon map** is a tuple of 2-tuples, where each 2-tuple consists of (azimuth,elevation). Azimuth is the compass direction in degrees (0° = north, 180° = south). The horizon map has to cover the whole range of azimuths that the sun travels through over the year (recommendation: plot the horizon from 0 to 360°). Elevation is the associated angle in degrees of any object (hill, tree, ...) casting a shadow on the modules. The elevation angle has to be in the range 0° (flat, ideal horizon) to 90° (in the sky directly over the modules). The map has to be monotonic on the azimuth axis, however this is not checked by the script! Elevation values in between are interpolated along the azimuth axis, thus non-monotonic values will give wrong results. The horizon map can also be passed from a text file, see the included example estimate_horizon.py.
 

--- a/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
+++ b/src/open_meteo_solar_forecast/open_meteo_solar_forecast.py
@@ -47,7 +47,7 @@ class OpenMeteoSolarForecast:
     past_days: int = 92
     forecast_days: int = 16
 
-    ac_kwp: float | None = None
+    ac_kwp: float | list[float | None] | None = None
     api_key: str | None = None
     base_url: str | None = None
     weather_model: str | None = None
@@ -153,6 +153,20 @@ class OpenMeteoSolarForecast:
             "horizon_map", self.dc_kwp, tuple_as_list=False
         )
         self.max_snowcover_depth_cm = test_param_len("max_snowcover_depth_cm", self.dc_kwp)
+
+        # A scalar ac_kwp models a single shared inverter that clamps the
+        # combined output of all arrays. A list/tuple models one inverter per
+        # array, clamping each array's output individually. None entries mean
+        # that array's inverter capacity is unlimited.
+        self.shared_inverter = not is_list_like(self.ac_kwp)
+        self.ac_kwp = [
+            float("inf") if cap is None else cap
+            for cap in test_param_len("ac_kwp", self.dc_kwp)
+        ]
+        for ac_kwp in self.ac_kwp:
+            if ac_kwp <= 0:
+                msg = f"ac_kwp must be greater than 0, got {ac_kwp}"
+                raise OpenMeteoSolarForecastConfigError(msg)
 
     async def _request(
         self,
@@ -369,6 +383,7 @@ class OpenMeteoSolarForecast:
             partial_shading,
             horizon_map,
             max_snowcover_depth_cm,
+            ac_kwp,
         ) in zip(
             self.azimuth,
             self.declination,
@@ -383,6 +398,7 @@ class OpenMeteoSolarForecast:
             self.partial_shading,
             self.horizon_map,
             self.max_snowcover_depth_cm,
+            self.ac_kwp,
             strict=True,
         ):
             '''
@@ -488,6 +504,10 @@ class OpenMeteoSolarForecast:
             # Convert kW to W
             dc_wp = dc_kwp * 1000
 
+            # Per-array inverter clamp (only when per-array capacities are
+            # given; a shared inverter clamps the combined output below)
+            ac_wp_array = float("inf") if self.shared_inverter else ac_kwp * 1000
+
             for i, time in enumerate(time_arr):
                 # Skip the first element as we need the previous element to calculate
                 # the average temperature for the current time
@@ -560,12 +580,23 @@ class OpenMeteoSolarForecast:
                     irr_avg *= snowcover_factor
                     irr_inst *= snowcover_factor
 
-                # Calculate and store the power generated
-                w_avg[time_start] += gen_power(irr_avg, temp_avg, eff_damped)
-                w_inst[time_start] += gen_power(irr_inst, temp_inst, eff_damped)
+                # Calculate and store the power generated, clamped to the
+                # array's own inverter capacity when one is configured
+                w_avg[time_start] += round(
+                    min(gen_power(irr_avg, temp_avg, eff_damped), ac_wp_array)
+                )
+                w_inst[time_start] += round(
+                    min(gen_power(irr_inst, temp_inst, eff_damped), ac_wp_array)
+                )
 
-        # Clamp the power generated to the AC power
-        ac_wp = self.ac_kwp * 1000  # Convert kW to W
+        # Clamp the power generated to the AC power of the inverter(s). With a
+        # shared inverter the combined output is clamped to its capacity; with
+        # per-array inverters each array was already clamped individually, so
+        # the combined output is limited by the sum of all capacities.
+        ac_kwp_total = (
+            self.ac_kwp[0] if self.shared_inverter else sum(self.ac_kwp)
+        )
+        ac_wp = ac_kwp_total * 1000  # Convert kW to W
         for time in w_avg:
             w_avg[time] = min(w_avg[time], ac_wp)
         for time in w_inst:

--- a/tests/test_ac_kwp.py
+++ b/tests/test_ac_kwp.py
@@ -1,0 +1,133 @@
+"""Tests for per-array inverter (AC) capacity support."""
+
+# ruff: noqa: S101
+
+import unittest
+from datetime import datetime, timezone
+
+from open_meteo_solar_forecast import OpenMeteoSolarForecast
+from open_meteo_solar_forecast.exceptions import OpenMeteoSolarForecastConfigError
+
+
+def _make_forecast(**kwargs) -> OpenMeteoSolarForecast:
+    """Create a two-array forecast object with sensible defaults."""
+    defaults = {
+        "latitude": [48.0, 48.0],
+        "longitude": [11.0, 11.0],
+        "declination": [20, 30],
+        "azimuth": [0, 0],
+        "dc_kwp": [2.0, 2.0],
+    }
+    defaults.update(kwargs)
+    return OpenMeteoSolarForecast(**defaults)
+
+
+class AcKwpConfigTests(unittest.TestCase):
+    """Verify ac_kwp validation and normalization."""
+
+    def test_default_is_shared_and_unlimited(self) -> None:
+        """Default to a shared inverter with unlimited capacity."""
+        forecast = _make_forecast()
+        assert forecast.shared_inverter is True
+        assert forecast.ac_kwp == [float("inf"), float("inf")]
+
+    def test_scalar_is_shared_inverter(self) -> None:
+        """Interpret a scalar as one inverter shared by all arrays."""
+        forecast = _make_forecast(ac_kwp=3.0)
+        assert forecast.shared_inverter is True
+        assert forecast.ac_kwp == [3.0, 3.0]
+
+    def test_list_is_per_array_inverters(self) -> None:
+        """Interpret a list as one inverter per array."""
+        forecast = _make_forecast(ac_kwp=[1.5, 2.5])
+        assert forecast.shared_inverter is False
+        assert forecast.ac_kwp == [1.5, 2.5]
+
+    def test_none_entry_means_unlimited(self) -> None:
+        """Allow None entries for arrays without an inverter limit."""
+        forecast = _make_forecast(ac_kwp=[1.5, None])
+        assert forecast.shared_inverter is False
+        assert forecast.ac_kwp == [1.5, float("inf")]
+
+    def test_length_mismatch_rejected(self) -> None:
+        """Reject ac_kwp lists that do not match the number of arrays."""
+        with self.assertRaises(OpenMeteoSolarForecastConfigError):
+            _make_forecast(ac_kwp=[1.0, 2.0, 3.0])
+
+    def test_non_positive_rejected(self) -> None:
+        """Reject zero or negative inverter capacities."""
+        with self.assertRaises(OpenMeteoSolarForecastConfigError):
+            _make_forecast(ac_kwp=0.0)
+        with self.assertRaises(OpenMeteoSolarForecastConfigError):
+            _make_forecast(ac_kwp=[1.0, -2.0])
+
+
+def _fake_api_data() -> dict:
+    """Build a minimal API response producing 2000 W per 2 kWp array."""
+    tz = timezone.utc
+    t0 = int(datetime(2026, 8, 14, 12, 0, tzinfo=tz).timestamp())
+    t1 = t0 + 900
+    day = int(datetime(2026, 8, 14, 0, 0, tzinfo=tz).timestamp())
+    sunrise = int(datetime(2026, 8, 14, 6, 0, tzinfo=tz).timestamp())
+    sunset = int(datetime(2026, 8, 14, 20, 0, tzinfo=tz).timestamp())
+    # With GTI = 1000 W/m² (G_STC) and an ambient temperature chosen so the
+    # cell temperature equals STC (25°C), each array produces exactly dc_wp.
+    t_amb = 25.0 - 1000.0 * 0.0342
+    return {
+        "utc_offset_seconds": 0,
+        "minutely_15": {
+            "time": [t0, t1],
+            "global_tilted_irradiance": [1000.0, 1000.0],
+            "global_tilted_irradiance_instant": [1000.0, 1000.0],
+            "diffuse_radiation": [0.0, 0.0],
+            "diffuse_radiation_instant": [0.0, 0.0],
+            "direct_radiation": [1000.0, 1000.0],
+            "direct_radiation_instant": [1000.0, 1000.0],
+            "snow_depth": [0.0, 0.0],
+            "temperature_2m": [t_amb, t_amb],
+        },
+        "daily": {
+            "time": [day],
+            "sunrise": [sunrise],
+            "sunset": [sunset],
+        },
+    }
+
+
+class AcKwpClampTests(unittest.IsolatedAsyncioTestCase):
+    """Verify inverter clamping behaviour in estimate()."""
+
+    @staticmethod
+    async def _estimate_total(forecast: OpenMeteoSolarForecast) -> float:
+        async def fake_request(uri, *, params=None):  # noqa: ARG001
+            return _fake_api_data()
+
+        forecast._request = fake_request  # noqa: SLF001
+        estimate = await forecast.estimate()
+        assert len(estimate.watts) == 1
+        return next(iter(estimate.watts.values()))
+
+    async def test_no_inverter_limit(self) -> None:
+        """Sum both arrays without clamping when no capacity is set."""
+        total = await self._estimate_total(_make_forecast())
+        assert total == 4000
+
+    async def test_shared_inverter_clamps_combined_output(self) -> None:
+        """Clamp the combined output to a shared inverter's capacity."""
+        total = await self._estimate_total(_make_forecast(ac_kwp=1.0))
+        assert total == 1000
+
+    async def test_per_array_inverters_clamp_individually(self) -> None:
+        """Clamp each array to its own inverter capacity before summing."""
+        # Array 1 (2000 W) clamped to 1000 W, array 2 (2000 W) unclamped.
+        total = await self._estimate_total(_make_forecast(ac_kwp=[1.0, 3.0]))
+        assert total == 3000
+
+    async def test_per_array_none_entry_is_unlimited(self) -> None:
+        """Leave arrays with a None capacity unclamped."""
+        total = await self._estimate_total(_make_forecast(ac_kwp=[1.0, None]))
+        assert total == 3000
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Allow ac_kwp to be passed as a list/tuple with one inverter capacity per array. Each array's output is then clamped to its own inverter before the outputs are combined, modeling setups where arrays are connected to separate inverters with different capacities. None entries mean no limit for that array.

A scalar ac_kwp keeps the previous behaviour: a single inverter shared by all arrays, clamping the combined output.

Fixes: https://github.com/rany2/ha-open-meteo-solar-forecast/issues/79